### PR TITLE
chore: use `recaptcha.net` CDN domain name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -104,7 +104,7 @@ class Reaptcha extends Component<Props> {
 
       script.async = true;
       script.defer = true;
-      script.src = 'https://google.com/recaptcha/api.js?render=explicit';
+      script.src = 'https://recaptcha.net/recaptcha/api.js?render=explicit';
 
       if (document.head) {
         document.head.appendChild(script);


### PR DESCRIPTION
since `*.google.com` is blocked by some people, we should load
recaptcha's api.js from the other domain: recaptcha.net .

FAQ: Can i use reCAPTCHA globally?

https://developers.google.com/recaptcha/docs/faq