### PR TITLE
fix: use props hl to init script to set up the correct language

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -73,7 +73,9 @@ class Reaptcha extends Component<Props, State> {
 
   _inject = (): void => {
     if (this.props.inject && !isAnyScriptPresent(RECAPTCHA_SCRIPTS_URLS)) {
-      injectScript(`${USED_RECAPTCHA_SCRIPT_URL}?render=explicit`);
+      injectScript(
+        `${USED_RECAPTCHA_SCRIPT_URL}?render=explicit&hl=${this.props.hl}`
+      );
     }
   };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,8 +73,8 @@ class Reaptcha extends Component<Props, State> {
 
   _inject = (): void => {
     if (this.props.inject && !isAnyScriptPresent(RECAPTCHA_SCRIPTS_URLS)) {
-      let src = `${USED_RECAPTCHA_SCRIPT_URL}?render=explicit`;
-      src = this.props.hl !== '' ? `${src}&hl=${this.props.hl}` : src;
+      const hlParam = this.props.hl ? `&hl=${this.props.hl}` : null;
+      const src = `${USED_RECAPTCHA_SCRIPT_URL}?render=explicit${hlParam}`;
       injectScript(src);
     }
   };

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,9 +73,9 @@ class Reaptcha extends Component<Props, State> {
 
   _inject = (): void => {
     if (this.props.inject && !isAnyScriptPresent(RECAPTCHA_SCRIPTS_URLS)) {
-      injectScript(
-        `${USED_RECAPTCHA_SCRIPT_URL}?render=explicit&hl=${this.props.hl}`
-      );
+      let src = `${USED_RECAPTCHA_SCRIPT_URL}?render=explicit`;
+      src = this.props.hl !== '' ? `${src}&hl=${this.props.hl}` : src;
+      injectScript(src);
     }
   };
 

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -239,12 +239,11 @@ test.serial('should inject script with hl parameter if specified', t => {
 
 test.serial('should not add hl parameter in script if not specified', t => {
   t.plan(3);
-  const hlValue = 'en';
   mount(<Reaptcha {...defaultProps} />);
   t.is(document.scripts.length, 1);
   const script = document.scripts[0];
   t.truthy(script.src);
-  t.notRegex(script.src, new RegExp(`hl=${hlValue}`));
+  t.notRegex(script.src, new RegExp('hl='));
 });
 
 test.serial('should inject only one script on multiple instances', t => {

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -237,6 +237,16 @@ test.serial('should inject script with hl parameter if specified', t => {
   t.regex(script.src, new RegExp(`hl=${hlValue}`));
 });
 
+test.serial('should not add hl parameter in script if not specified', t => {
+  t.plan(3);
+  const hlValue = 'en';
+  mount(<Reaptcha {...defaultProps} />);
+  t.is(document.scripts.length, 1);
+  const script = document.scripts[0];
+  t.truthy(script.src);
+  t.notRegex(script.src, new RegExp(`hl=${hlValue}`));
+});
+
 test.serial('should inject only one script on multiple instances', t => {
   t.plan(1);
 

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -212,10 +212,8 @@ test.serial('should inject script', t => {
   t.plan(4);
 
   mount(<Reaptcha {...defaultProps} />);
-
   t.is(document.scripts.length, 1);
   const script = document.scripts[0];
-
   t.true(script.async);
   t.true(script.defer);
   t.truthy(script.src);
@@ -227,6 +225,16 @@ test.serial('should not inject script', t => {
   mount(<Reaptcha {...defaultProps} inject={false} />);
 
   t.is(document.scripts.length, 0);
+});
+
+test.serial('should inject script with hl parameter if specified', t => {
+  t.plan(3);
+  const hlValue = 'en';
+  mount(<Reaptcha {...defaultProps} hl={hlValue} />);
+  t.is(document.scripts.length, 1);
+  const script = document.scripts[0];
+  t.truthy(script.src);
+  t.regex(script.src, new RegExp(`hl=${hlValue}`));
 });
 
 test.serial('should inject only one script on multiple instances', t => {


### PR DESCRIPTION
When the component inject automatically the script, it take the hl props passed by the user to set the correct language.