### PR TITLE
Fix README example code link

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ First of all, you'll need a reCAPTCHA API key. To find out how to get it - [chec
 
 To see how `Reaptcha` actually works, visit the [example page](https://sarneeh.github.io/reaptcha).
 
-If you'd also like to see the code for the example, it is right [here](https://github.com/sarneeh/reaptcha/tree/docs/example/src).
+If you'd also like to see the code for the example, it is right [here](https://github.com/sarneeh/reaptcha/tree/master/example/src).
 
 ### Default - Automatic render
 


### PR DESCRIPTION
First of all thank you for this package! The other recaptcha packages I have used seem to be slightly lower quality and sometimes buggy. I found a tiny issue on the readme while testing out this library:

In the README there was a link to the example code that pointed to a docs branch that seems to no longer exist. I updated this to point at the master branch as there wasn't a suitable substitute.

Cheers,

Konrad